### PR TITLE
Fix database backup character set

### DIFF
--- a/functions.inc/class.backup.php
+++ b/functions.inc/class.backup.php
@@ -263,7 +263,7 @@ class Backup {
 									. '.' . backup__($x);
 						}
 					}
-					$cmd[] = ' --opt --skip-comments --skip-extended-insert --lock-tables=false --skip-add-locks --compatible=no_table_options ';
+					$cmd[] = ' --opt --skip-comments --skip-extended-insert --lock-tables=false --skip-add-locks --compatible=no_table_options --default-character-set=utf8';
 
 					// Need to grep out leading /* comments and SET commands as they create problems
 					// restoring using the PEAR $db class


### PR DESCRIPTION
We should use --default-character-set=utf8 option to do valid database backup.