### PR TITLE
Right nav improvements

### DIFF
--- a/Backup.class.php
+++ b/Backup.class.php
@@ -320,7 +320,10 @@ class Backup implements \BMO {
 		return $backups;
 	}
 	public function getRightNav($request) {
-		$var = array();
+		$var = array(
+			'id' => isset($request['id']) ? $request['id'] : '',
+			'display' => isset($request['display']) ? $request['display'] : '',
+		);
 		switch ($request['display']) {
 			case 'backup':
 				if(isset($request['action']) && $request['action'] == 'edit'){

--- a/views/rnav/backup.php
+++ b/views/rnav/backup.php
@@ -4,7 +4,7 @@ if (isset($backup)){
 	foreach ($backup as $b) {
 		$li[] = '<a '
 			. ( $id == $b['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"')
-			. '" href="config.php?display=backup&action=edit&id='
+			. ' href="config.php?display=backup&action=edit&id='
 			. $b['id'] . '">'
 			. $b['name']
 			.'</a>';

--- a/views/rnav/backup.php
+++ b/views/rnav/backup.php
@@ -1,15 +1,17 @@
 <?php
 require(dirname(__FILE__) . '/main.php');
-if (isset($backup)){
+
+if (isset($backup)) {
 	foreach ($backup as $b) {
-		$li[] = '<a '
-			. ( $id == $b['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"')
-			. ' href="config.php?display=backup&action=edit&id='
-			. $b['id'] . '">'
-			. $b['name']
-			.'</a>';
+		$li[] = sprintf(
+			'<a href="config.php?display=backup&amp;action=edit&amp;id=%d" class="list-group-item %s">%s</a>',
+			$b['id'],
+			($id == $b['id'] ? 'active' : ''),
+			htmlspecialchars($b['name'])
+		);
 	}
 }
- foreach ($li as $item) {
- 	echo $item;
- }
+
+foreach ($li as $item) {
+	echo $item;
+}

--- a/views/rnav/backup.php
+++ b/views/rnav/backup.php
@@ -3,7 +3,7 @@ require(dirname(__FILE__) . '/main.php');
 if (isset($backup)){
 	foreach ($backup as $b) {
 		$li[] = '<a '
-			. ( $id == $b['id'] ? ' class="list-group-item current" ' : ' class="list-group-item"')
+			. ( $id == $b['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"')
 			. '" href="config.php?display=backup&action=edit&id='
 			. $b['id'] . '">'
 			. $b['name']

--- a/views/rnav/main.php
+++ b/views/rnav/main.php
@@ -13,7 +13,7 @@ foreach ($list as $k => $v) {
 		continue;
 	}
 	$li[] = '<a href="config.php?display=' . $k . '"'
-			. ( $display == $k ? ' class="list-group-item current" ' : ' class="list-group-item"')
+			. ( $display == $k ? ' class="list-group-item active" ' : ' class="list-group-item"')
 			. '>' 
 			. $v . '</a>';
 }

--- a/views/rnav/main.php
+++ b/views/rnav/main.php
@@ -5,6 +5,8 @@ $list = array(
 			'backup_servers'	=> _('Servers'),
 			'backup_templates'	=>  _('Templates')
 		);
+
+$li = array();
 		
 foreach ($list as $k => $v) {
 	// If current user does not have access to this sub-menu then don't display it
@@ -12,9 +14,12 @@ foreach ($list as $k => $v) {
 	if (is_object($_SESSION["AMP_user"]) && !$_SESSION["AMP_user"]->checkSection($k)) {
 		continue;
 	}
-	$li[] = '<a href="config.php?display=' . $k . '"'
-			. ( $display == $k ? ' class="list-group-item active" ' : ' class="list-group-item"')
-			. '>' 
-			. $v . '</a>';
+	$li[] = sprintf(
+		'<a href="config.php?display=%s" class="list-group-item %s">%s<a/>',
+		$k,
+		($display == $k ? 'active' : ''),
+		htmlspecialchars($v)
+	);
+
 }
 $li[] = '<hr />';

--- a/views/rnav/restore.php
+++ b/views/rnav/restore.php
@@ -10,7 +10,7 @@ if (isset($servers)){
 		}
 		
 		$li[] = '<a ' 
-			. ( $id == $s['id'] ? ' class="list-group-item current" ' : ' class="list-group-item"') 
+			. ( $id == $s['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"') 
 			. '" href="config.php?display=backup_restore&id=' 
 			. $s['id'] . '">' 
 			. $s['name'] 

--- a/views/rnav/restore.php
+++ b/views/rnav/restore.php
@@ -1,25 +1,24 @@
 <?php
-
 require(dirname(__FILE__) . '/main.php');
 $allowed = array('ftp', 'local', 'ssh','awss3');
-if (isset($servers)){
+
+if (isset($servers)) {
 	foreach ($servers as $s) {
 		//only allow servers in $allowed
 		if (!in_array($s['type'], $allowed)) { 
 			continue;
 		}
-		
-		$li[] = '<a ' 
-			. ( $id == $s['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"') 
-			. ' href="config.php?display=backup_restore&id=' 
-			. $s['id'] . '">' 
-			. $s['name'] 
-			. ' (' . $s['type'] . ')'
-			.'</a>';
-	}
 
+		$li[] = sprintf(
+			'<a href="config.php?display=backup_restore&amp;id=%d" class="list-group-item %s">%s (%s)</a>',
+			$s['id'],
+			($id == $s['id'] ? 'active' : ''),
+			htmlspecialchars($s['name']),
+			htmlspecialchars($s['type'])
+		);
+	}
 }	
 
- foreach ($li as $item) {
- 	echo $item;
- }
+foreach ($li as $item) {
+	echo $item;
+}

--- a/views/rnav/restore.php
+++ b/views/rnav/restore.php
@@ -11,7 +11,7 @@ if (isset($servers)){
 		
 		$li[] = '<a ' 
 			. ( $id == $s['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"') 
-			. '" href="config.php?display=backup_restore&id=' 
+			. ' href="config.php?display=backup_restore&id=' 
 			. $s['id'] . '">' 
 			. $s['name'] 
 			. ' (' . $s['type'] . ')'

--- a/views/rnav/servers.php
+++ b/views/rnav/servers.php
@@ -5,7 +5,7 @@ if (isset($servers)){
 	foreach ($servers as $s) {
 		$li[] = '<a ' 
 				. ( $id == $s['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"') 
-				. '" href="config.php?display=backup_servers&action=edit&id=' 
+				. ' href="config.php?display=backup_servers&action=edit&id=' 
 				. $s['id'] . '">' 
 				. $s['name'] 
 				. ' (' . $s['type'] . ')'

--- a/views/rnav/servers.php
+++ b/views/rnav/servers.php
@@ -4,7 +4,7 @@ require(dirname(__FILE__) . '/main.php');
 if (isset($servers)){
 	foreach ($servers as $s) {
 		$li[] = '<a ' 
-				. ( $id == $s['id'] ? ' class="list-group-item current" ' : ' class="list-group-item"') 
+				. ( $id == $s['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"') 
 				. '" href="config.php?display=backup_servers&action=edit&id=' 
 				. $s['id'] . '">' 
 				. $s['name'] 

--- a/views/rnav/servers.php
+++ b/views/rnav/servers.php
@@ -1,19 +1,18 @@
 <?php
 require(dirname(__FILE__) . '/main.php');
 
-if (isset($servers)){
+if (isset($servers)) {
 	foreach ($servers as $s) {
-		$li[] = '<a ' 
-				. ( $id == $s['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"') 
-				. ' href="config.php?display=backup_servers&action=edit&id=' 
-				. $s['id'] . '">' 
-				. $s['name'] 
-				. ' (' . $s['type'] . ')'
-				.'</a>';
+		$li[] = sprintf(
+			'<a href="config.php?display=backup_servers&amp;action=edit&amp;id=%d" class="list-group-item %s">%s (%s)</a>',
+			$s['id'],
+			($id == $s['id'] ? 'active' : ''),
+			htmlspecialchars($s['name']),
+			htmlspecialchars($s['type'])
+		);
 	}
-
 }	
 
- foreach ($li as $item) {
- 	echo $item;
- }
+foreach ($li as $item) {
+	echo $item;
+}

--- a/views/rnav/templates.php
+++ b/views/rnav/templates.php
@@ -5,7 +5,7 @@ require(dirname(__FILE__) . '/main.php');
 if (isset($templates)){
 	foreach ($templates as $t) {
 		$li[] = '<a ' 
-			. ( $id == $t['id'] ? ' class="list-group-item current" ' : ' class="list-group-item"') 
+			. ( $id == $t['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"') 
 			. '" href="config.php?display=backup_templates&action=edit&id=' 
 			. $t['id'] . '">' 
 			. $t['name'] 

--- a/views/rnav/templates.php
+++ b/views/rnav/templates.php
@@ -1,18 +1,17 @@
 <?php
-
 require(dirname(__FILE__) . '/main.php');
 
-if (isset($templates)){
+if (isset($templates)) {
 	foreach ($templates as $t) {
-		$li[] = '<a ' 
-			. ( $id == $t['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"') 
-			. ' href="config.php?display=backup_templates&action=edit&id=' 
-			. $t['id'] . '">' 
-			. $t['name'] 
-			.'</a>';
+		$li[] = sprintf(
+			'<a href="config.php?display=backup_templates&amp;action=edit&amp;id=%s" class="list-group-item %s">%s</a>',
+			htmlspecialchars($t['id']),
+			($id == $t['id'] ? 'active' : ''),
+			htmlspecialchars($t['name'])
+		);
 	}
 }	
 
- foreach ($li as $item) {
- 	echo $item;
- }
+foreach ($li as $item) {
+	echo $item;
+}

--- a/views/rnav/templates.php
+++ b/views/rnav/templates.php
@@ -6,7 +6,7 @@ if (isset($templates)){
 	foreach ($templates as $t) {
 		$li[] = '<a ' 
 			. ( $id == $t['id'] ? ' class="list-group-item active" ' : ' class="list-group-item"') 
-			. '" href="config.php?display=backup_templates&action=edit&id=' 
+			. ' href="config.php?display=backup_templates&action=edit&id=' 
 			. $t['id'] . '">' 
 			. $t['name'] 
 			.'</a>';


### PR DESCRIPTION
This started out as an undefined variable hunt, but I noticed a bunch of other stuff on the way.

The final commit 440e2cd is a matter of personal preference, but I believe it looks cleaner and that it's a lot easier to follow a `sprintf()` call than a bunch of multi-line concats with nested quotes. (Also included in that commit is HTML escaping for string values, which is definitely something that shouldn't be omitted.)
