### PR TITLE
Allow for S3 policies where we only have PutObject rights

### DIFF
--- a/functions.inc/class.backup.php
+++ b/functions.inc/class.backup.php
@@ -498,17 +498,25 @@ class Backup {
 					$this->maintenance($s['type'], $path, $ftp);
 					break;
 				case 'awss3':
-					//subsitute variables if nesesary
+					//substitute variables if necessary
 					$s['bucket'] 		= backup__($s['bucket']);
 					$s['awsaccesskey'] 	= backup__($s['awsaccesskey']);
 					$s['awssecret'] 	= backup__($s['awssecret']);
 					$awss3 = new \S3($s['awsaccesskey'], $s['awssecret']);
 
 					// Does this bucket already exist?
-					$buckets = $awss3->listBuckets();
-					if (!in_array($s['bucket'], $buckets)) {
-						// Create the bucket
-						$awss3->putBucket($s['bucket'], \S3::ACL_PRIVATE);
+					// In hyper-secure environments we may not have permission to 
+					//	list the bucket, try to, but if we can't just move on.
+					try {
+						$buckets = $awss3->listBuckets();
+						if (!in_array($s['bucket'], $buckets)) {
+							// Create the bucket
+							$awss3->putBucket($s['bucket'], \S3::ACL_PRIVATE);
+						}
+					}
+					catch (\Exception $e)
+					{
+						backup_log("Unable to list buckets: " . $e->getMessage());
 					}
 
 					//copy file
@@ -519,7 +527,15 @@ class Backup {
 					}
 
 					//run maintenance on the directory
-					$this->maintenance($s['type'], $s, $awss3);
+					// In hyper-secure environments we may not have permission to 
+					//	cleanup up the bucket, try to, but if we can't just move on.
+					try {
+						$this->maintenance($s['type'], $s, $awss3);
+					}
+					catch (\Exception $e)
+					{
+						backup_log("Unable to perform maintenance: " . $e->getMessage());
+					}
 
 					break;
 				case 'ssh':


### PR DESCRIPTION
It's not uncommon to use prefix-based access control to allow users only access to "subfolders" in S3. Likewise, we may not be able to list the contents of our backup location nor have permission to delete items there so the maintenance may fail as well. Allow for these possiblities by just logging the fact but continuing the backup. If there is truly a problem with the bucket the putObject() call will still fail the backup.