### PR TITLE
Check for existence of a private key, not public

### DIFF
--- a/Backup.class.php
+++ b/Backup.class.php
@@ -611,7 +611,7 @@ class Backup extends FreePBX_Helpers implements BMO {
 			case 'settings':
 				$vars = [];
 				$hdir = $this->getAsteriskUserHomeDir();
-				$file = $hdir.'/.ssh/id_rsa.pub';
+				$file = $hdir.'/.ssh/id_rsa';
 				if (!file_exists($file)) {
 					$ssh = new FilestoreRemote();
 					$ssh->generateKey($hdir.'/.ssh');


### PR DESCRIPTION
This code would have overwritten an existing key just because it had no public key (which is not needed for automated processes like this.)