### PR TITLE
Add File Size in Backup API #334

### DIFF
--- a/Api/Gql/Backup.php
+++ b/Api/Gql/Backup.php
@@ -224,6 +224,10 @@ class Backup extends Base {
 					'type' => Type::String(),
 					'description' => _('Return backup file name')
 				],
+				'size' => [
+					'type' => Type::String(),
+					'description' => _('Return backup file size')
+				],
 				'framework' => [
 					'type' => Type::String(),
 					'description' => _('Return backup framework')


### PR DESCRIPTION
To be consistent with the GUI, fetchAllBackups should provide the field "Size" in the list.