### PR TITLE
Backup: Fix issue 122

### DIFF
--- a/Backup.class.php
+++ b/Backup.class.php
@@ -1328,12 +1328,14 @@ public function GraphQL_Access_token($request) {
 				continue;
 			}
 
-			$value = $this->getReqUnsafe($col,'');
-			if($col == 'backup_name'){
-				$value = str_replace(' ', '-', (string) $value); 
-				$value = preg_replace('/[^A-Za-z0-9\-]/', '', $value);
+			if(isset($_REQUEST[$col]) || $_REQUEST['action'] == "addbackup") {
+				$value = $this->getReqUnsafe($col,'');
+				if($col == 'backup_name'){
+					$value = str_replace(' ', '-', (string) $value);
+					$value = preg_replace('/[^A-Za-z0-9\-]/', '', $value);
+				}
+				$this->updateBackupSetting($data['id'], $col, $value);
 			}
-			$this->updateBackupSetting($data['id'], $col, $value);
 		}
 
 		$backup_name = $this->getReq('backup_name','');

--- a/views/backup/form.php
+++ b/views/backup/form.php
@@ -32,6 +32,7 @@ if (!empty($bkjobs)) {
 						<input type="hidden" id="id" name="id" value="<?php echo $id ?>">
 						<input type="hidden" id="backup_items" name="backup_items" value='unchanged'>
 						<input type="hidden" id="backup_schedule" name="backup_schedule" value="<?php echo $backup_schedule ?>">
+						<input type="hidden" id="action" name="action" value="<?php echo $_REQUEST['view'] ?>">
 						<div class="section-title" data-for="backup-basic">
 							<h3>
 								<i class="fa fa-minus"></i>


### PR DESCRIPTION
The function _updateBackupSetting()_ deletes the setting from the Menu "Backup Items" if a backup-job is edited without opening this menu (see [this](https://github.com/FreePBX/issue-tracker/issues/122#issuecomment-2666087647) comment for details). The function _updateBackupSetting()_ should only be called, if a new backup-job is created or a backup-job is edited and the menu was opened

Bugfix FreePBX/issue-tracker#122