### PR TITLE
ISSUE-122 Trunks are not being disabled when a warm spare backup is performed 

### DIFF
--- a/Backup.class.php
+++ b/Backup.class.php
@@ -1165,6 +1165,10 @@ public function GraphQL_Access_token($request) {
 				$value = str_replace(' ', '-', $value); 
 				$value = preg_replace('/[^A-Za-z0-9\-]/', '', $value);
 			}
+			if($col == 'core_disabletrunks') {
+				$disableTrunkValue = $this->freepbx->Core->getConfig('core_disabletrunks', $data['id']);
+				$value = (!empty($disableTrunkValue) ? $disableTrunkValue : 'no');
+			}
 			$this->updateBackupSetting($data['id'], $col, $value);
 		}
 


### PR DESCRIPTION
This PR will fix the Disable Trunks on Restore setting issue.