### PR TITLE
Add console block to module.xml

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -120,4 +120,11 @@
 	<supported>
 		<version>16.0</version>
 	</supported>
+	<console>
+		<command>
+			<name>backup</name>
+			<alias>bu</alias>
+			<class>Backup</class>
+		</command>
+    </console>
 </module>


### PR DESCRIPTION
This PR add  the console block to the file module.xml to prevent the message "Deprecated way to add Console commands for module" for FreePBX 16

Bugfix FreePBX/issue-tracker#278